### PR TITLE
Add simple PWA for beauty institute

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,12 @@
-# App2converter
+# Institut de Beauté - Application Web
+
+Cette application web fournit une démonstration simple pour un institut de beauté fictif. Elle peut être installée sur un smartphone comme une application grâce au manifest intégré.
+
+## Contenu
+- **index.html** : page d'accueil présentant l'institut, les prestations, les tarifs et les promotions.
+- **contact.html** : liens rapides vers WhatsApp, téléphone et Google Maps.
+- **gallery.html** : galerie avant/après.
+- **manifest.json** : manifest pour l'installation de l'application.
+- **service-worker.js** : met en cache les ressources pour un fonctionnement hors‑ligne.
+
+Pour tester l'application, ouvrez `index.html` dans un navigateur moderne et suivez l'invite d'installation.

--- a/contact.html
+++ b/contact.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="manifest" href="manifest.json">
+  <link rel="stylesheet" href="style.css">
+  <title>Contact - Institut de Beauté</title>
+</head>
+<body>
+  <header>
+    <h1>Contact</h1>
+  </header>
+  <nav>
+    <a href="index.html">Accueil</a>
+    <a href="contact.html">Contact</a>
+    <a href="gallery.html">Galerie</a>
+  </nav>
+  <div class="container">
+    <p>Pour toute question ou prise de rendez-vous :</p>
+    <ul>
+      <li><a href="https://wa.me/33123456789" target="_blank">WhatsApp</a></li>
+      <li><a href="tel:+33123456789">Téléphone : 01 23 45 67 89</a></li>
+      <li><a href="https://maps.google.com/?q=Mon+Institut" target="_blank">Adresse sur Google Maps</a></li>
+    </ul>
+  </div>
+  <footer>
+    <p>&copy; 2024 Institut de Beauté</p>
+  </footer>
+</body>
+</html>

--- a/gallery.html
+++ b/gallery.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="manifest" href="manifest.json">
+  <link rel="stylesheet" href="style.css">
+  <title>Galerie - Institut de Beauté</title>
+</head>
+<body>
+  <header>
+    <h1>Galerie Avant / Après</h1>
+  </header>
+  <nav>
+    <a href="index.html">Accueil</a>
+    <a href="contact.html">Contact</a>
+    <a href="gallery.html">Galerie</a>
+  </nav>
+  <div class="container">
+    <div class="gallery">
+      <img src="images/before.svg" alt="Avant">
+      <img src="images/after.svg" alt="Après">
+    </div>
+  </div>
+  <footer>
+    <p>&copy; 2024 Institut de Beauté</p>
+  </footer>
+</body>
+</html>

--- a/images/after.svg
+++ b/images/after.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='400' height='400'>
+  <rect width='100%' height='100%' fill='lightblue'/>
+  <text x='50%' y='50%' dominant-baseline='middle' text-anchor='middle' font-size='40'>Après</text>
+</svg>

--- a/images/before.svg
+++ b/images/before.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='400' height='400'>
+  <rect width='100%' height='100%' fill='pink'/>
+  <text x='50%' y='50%' dominant-baseline='middle' text-anchor='middle' font-size='40'>Avant</text>
+</svg>

--- a/images/icon.svg
+++ b/images/icon.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='512' height='512'>
+  <rect width='100%' height='100%' rx='30' ry='30' fill='#ff69b4'/>
+  <text x='50%' y='50%' dominant-baseline='middle' text-anchor='middle' font-size='80' fill='white'>IB</text>
+</svg>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="manifest" href="manifest.json">
+  <link rel="stylesheet" href="style.css">
+  <title>Institut de Beauté</title>
+</head>
+<body>
+  <header>
+    <h1>Institut de Beauté</h1>
+    <button id="installBtn">Installer l'application</button>
+  </header>
+  <nav>
+    <a href="index.html">Accueil</a>
+    <a href="contact.html">Contact</a>
+    <a href="gallery.html">Galerie</a>
+  </nav>
+  <div class="container">
+    <h2>Bienvenue dans notre institut</h2>
+    <p>Notre institut vous propose une large gamme de soins pour sublimer votre beauté.</p>
+    <h3>Prestations et tarifs</h3>
+    <ul>
+      <li>Soin du visage - 50€</li>
+      <li>Manucure - 30€</li>
+      <li>Massage relaxant - 60€</li>
+    </ul>
+    <h3>Réservation</h3>
+    <p>Réservez votre prochain soin via <a href="https://www.planity.com/" target="_blank">Planity</a>.</p>
+    <h3>Promotions et événements</h3>
+    <p>Profitez de -10% sur toutes les prestations chaque premier lundi du mois !</p>
+  </div>
+  <footer>
+    <p>&copy; 2024 Institut de Beauté</p>
+  </footer>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,20 @@
+{
+  "name": "Institut de Beauté",
+  "short_name": "Institut",
+  "start_url": ".",
+  "display": "standalone",
+  "background_color": "#ffffff",
+  "theme_color": "#ff69b4",
+  "icons": [
+    {
+      "src": "images/icon.svg",
+      "sizes": "192x192",
+      "type": "image/svg+xml"
+    },
+    {
+      "src": "images/icon.svg",
+      "sizes": "512x512",
+      "type": "image/svg+xml"
+    }
+  ]
+}

--- a/script.js
+++ b/script.js
@@ -1,0 +1,25 @@
+if ('serviceWorker' in navigator) {
+  navigator.serviceWorker.register('/service-worker.js');
+}
+
+// Install prompt
+let deferredPrompt;
+const installBtn = document.getElementById('installBtn');
+window.addEventListener('beforeinstallprompt', (e) => {
+  e.preventDefault();
+  deferredPrompt = e;
+  if (installBtn) installBtn.style.display = 'block';
+});
+
+if (installBtn) {
+  installBtn.addEventListener('click', async () => {
+    if (deferredPrompt) {
+      deferredPrompt.prompt();
+      const { outcome } = await deferredPrompt.userChoice;
+      if (outcome === 'accepted') {
+        installBtn.style.display = 'none';
+      }
+      deferredPrompt = null;
+    }
+  });
+}

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,0 +1,26 @@
+self.addEventListener('install', function(e) {
+  e.waitUntil(
+    caches.open('beauty-store').then(function(cache) {
+      return cache.addAll([
+        '/',
+        '/index.html',
+        '/contact.html',
+        '/gallery.html',
+        '/style.css',
+        '/script.js',
+        '/manifest.json',
+        '/images/icon.svg',
+        '/images/before.svg',
+        '/images/after.svg'
+      ]);
+    })
+  );
+});
+
+self.addEventListener('fetch', function(event) {
+  event.respondWith(
+    caches.match(event.request).then(function(response) {
+      return response || fetch(event.request);
+    })
+  );
+});

--- a/style.css
+++ b/style.css
@@ -1,0 +1,52 @@
+body {
+  font-family: Arial, sans-serif;
+  margin: 0;
+  padding: 0;
+  line-height: 1.6;
+}
+
+header, nav, footer {
+  background: #ff69b4;
+  color: white;
+  padding: 10px;
+  text-align: center;
+}
+
+nav a {
+  color: white;
+  margin: 0 10px;
+  text-decoration: none;
+}
+
+.container {
+  padding: 20px;
+}
+
+.gallery {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  justify-content: center;
+}
+
+.gallery img {
+  width: 45%;
+  max-width: 400px;
+  height: auto;
+}
+
+@media (max-width: 600px) {
+  .gallery img {
+    width: 100%;
+  }
+}
+
+button#installBtn {
+  display: none;
+  margin-top: 10px;
+  padding: 10px 20px;
+  background: #ff69b4;
+  color: white;
+  border: none;
+  border-radius: 5px;
+}


### PR DESCRIPTION
## Summary
- rebuild README for beauty institute app
- add installable PWA with basic pages
- create placeholder icon and gallery images
- cache assets with a service worker

## Testing
- `git status --short`
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_68508ed207308329b15e432023799227